### PR TITLE
refactored mallocs and serialize blocks/headers

### DIFF
--- a/src/core/blocks/base_block.c
+++ b/src/core/blocks/base_block.c
@@ -1,0 +1,59 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "base_block.h"
+
+char * ser_BlockHeader(BlockHeader *block_header, char* dest){
+    memcpy(dest, &(block_header->timestamp), sizeof(block_header->timestamp));
+
+    char * all_tx = dest+sizeof(block_header->timestamp);
+    memcpy(all_tx, &(block_header->all_tx), sizeof(block_header->all_tx));
+
+    char * prev_header_hash = all_tx+sizeof(block_header->all_tx);
+    memcpy(prev_header_hash, &(block_header->prev_header_hash), sizeof(block_header->prev_header_hash));
+
+    char * nonce = prev_header_hash+sizeof(block_header->prev_header_hash);
+    memcpy(prev_header_hash, &(block_header->nonce), sizeof(block_header->nonce));
+
+    char* terminate = nonce+sizeof(block_header->nonce);
+    return terminate;
+}
+
+char * ser_BlockHeader_alloc(BlockHeader *block_header){
+    char * data = malloc(sizeof(BlockHeader));
+    memcpy(data, &(block_header->timestamp), sizeof(block_header->timestamp));
+
+    char * all_tx = data+sizeof(block_header->timestamp);
+    memcpy(all_tx, &(block_header->all_tx), sizeof(block_header->all_tx));
+
+    char * prev_header_hash = all_tx+sizeof(block_header->all_tx);
+    memcpy(prev_header_hash, &(block_header->prev_header_hash), sizeof(block_header->prev_header_hash));
+
+    char * nonce = prev_header_hash+sizeof(block_header->prev_header_hash);
+    memcpy(prev_header_hash, &(block_header->nonce), sizeof(block_header->nonce));
+
+    return data;
+}
+
+int size_block(Block *block){
+    int size = (sizeof(block->num_txs) + sizeof(block->header));
+    for(int i=0; i<block->num_txs; i++){
+        size += size_tx(&(block->txs[i]));
+    }
+    return size;
+}
+
+char * ser_Block(Block *block){
+    char * data = malloc(size_block(block));
+    memcpy(data, block->num_txs, sizeof(block->num_txs));
+
+    char * block_header = data+sizeof(block->num_txs);
+    char * txs = ser_BlockHeader(&(block->header), block_header);
+
+    for(int i=0; i<block->num_txs;i++){
+        char *txs = ser_tx(&(block->txs[i]), txs);
+    }
+    char * terminate = txs;
+  return data;
+}

--- a/src/core/txs/base_tx.c
+++ b/src/core/txs/base_tx.c
@@ -32,11 +32,32 @@ UTXO * dser_UTXO(char * data){
   return new_UTXO;
 }
 
-char * ser_tx(Transaction *tx){
+int size_tx(Transaction *tx){
+    return (sizeof(tx->num_inputs)+sizeof(tx->num_outputs) +
+      tx->num_inputs*sizeof(Input) + tx->num_outputs*sizeof(Output)+sizeof(char));
+}
+
+char * ser_tx(Transaction *tx, char* dest){
+  memcpy(dest, &(tx->num_inputs), sizeof(tx->num_inputs));
+
+  char * num_outputs = dest+sizeof(tx->num_inputs);
+  memcpy(num_outputs, &(tx->num_outputs), sizeof(tx->num_outputs));
+
+  char * inputs = num_outputs+sizeof(tx->num_outputs);
+  memcpy(inputs, tx->inputs, tx->num_inputs*sizeof(Input));
+
+  char * outputs = inputs + tx->num_inputs*sizeof(Input);
+  memcpy(outputs, tx->outputs, tx->num_outputs*sizeof(Output));
+
+  char * terminate = outputs + tx->num_outputs*sizeof(Output);
+  terminate = '\0';
+  return terminate;
+}
+
+char * ser_tx_alloc(Transaction *tx){
   // Determine total Size in bytes
   // This might be bad...https://stackoverflow.com/questions/119123/why-isnt-sizeof-for-a-struct-equal-to-the-sum-of-sizeof-of-each-member?rq=1
-  int total_size = (sizeof(tx->num_inputs)+sizeof(tx->num_outputs) +
-      tx->num_inputs*sizeof(Input) + tx->num_outputs*sizeof(Output)+sizeof(char));
+  int total_size = size_tx(tx);
 
   printf("Size Transaction (Bytes): %i\n", total_size);
   //Pack it all in

--- a/src/includes/blocks/base_block.h
+++ b/src/includes/blocks/base_block.h
@@ -6,15 +6,20 @@
 
 typedef struct BlockHeader{
     unsigned long timestamp;
-    char all_tx[TX_HASH_LEN];
-    char prev_header_hash[BLOCK_HASH_LEN];
+    unsigned char all_tx[TX_HASH_LEN];
+    unsigned char prev_header_hash[BLOCK_HASH_LEN];
     int nonce;
 } BlockHeader;
 
 typedef struct Block{
-    int num_txs;
+    unsigned int num_txs;
     BlockHeader header;
     Transaction *txs;
 } Block;
 
 #endif
+
+char * ser_BlockHeader(BlockHeader *block_header, char* dest);
+char * ser_BlockHeader_alloc(BlockHeader *block_header);
+
+char * ser_Block(Block *block);

--- a/src/includes/txs/base_tx.h
+++ b/src/includes/txs/base_tx.h
@@ -8,12 +8,12 @@
 
 typedef struct Output{
     unsigned long amt;
-    char public_key_hash[LOCK_SCRIPT_LEN];
+    unsigned char public_key_hash[LOCK_SCRIPT_LEN];
 } Output;
 
 typedef struct Input{
     char signature[SIGNATURE_LEN];
-    char prev_tx_id[TX_HASH_LEN];
+    unsigned char prev_tx_id[TX_HASH_LEN];
     int prev_utxo_output;
 } Input; 
 
@@ -32,7 +32,14 @@ typedef struct UTXO{
 
 char* ser_UTXO(UTXO *utxo);
 UTXO* dser_UTXO(char *data);
-char* ser_tx(Transaction *tx);
+
+/*
+Return Size of a transaction, used for serialization and memory allocation
+*/
+int size_tx(Transaction *tx);
+
+char* ser_tx(Transaction *tx, char* dest);
+char* ser_tx_alloc(Transaction *tx);
 Transaction* deser_tx(char *data);
 void hash_tx(Transaction *tx, unsigned char *buf);
 

--- a/src/tests/core/txs/test_base_tx.c
+++ b/src/tests/core/txs/test_base_tx.c
@@ -42,7 +42,7 @@ int main() {
   // //printf("prev_tx_id: %s\n", ((a_Tx->inputs)+1)->prev_tx_id);
 
   //Serialization Testing
-  char* char_tx = ser_tx(a_Tx);
+  char* char_tx = ser_tx_alloc(a_Tx);
 
   Transaction * other_tx = deser_tx(char_tx);
 


### PR DESCRIPTION
decided to serialize blocks, which meant I needed to do a little cleaner job on how to de serialize the nested structures, this is clean because now you can pass in a memory address that is already allocated. note thtat the _alloc versions return pointer to the beginning of data where as ones passed a pointer return the next memory address in case that is important (akak copying other mmemory to the next spot)
