### PR TITLE
Hashmap Functions

### DIFF
--- a/src/core/blocks/base_block.c
+++ b/src/core/blocks/base_block.c
@@ -26,10 +26,10 @@ unsigned char *ser_blockheader_alloc(BlockHeader *block_header){
   return data;
 }
 
-void hash_blockheader(BlockHeader *header, unsigned char *buf) {
+void hash_blockheader(unsigned char *dest, BlockHeader *header) {
   unsigned char *header_buf;
   header_buf = ser_blockheader_alloc(header);
-  hash_sha256(buf, header_buf, sizeof(BlockHeader));
+  hash_sha256(dest, header_buf, sizeof(BlockHeader));
   free(header_buf);
 }
 

--- a/src/core/blocks/base_block.c
+++ b/src/core/blocks/base_block.c
@@ -4,30 +4,30 @@
 
 #include "base_block.h"
 
-char *ser_blockheader(char *dest, BlockHeader *block_header){
+unsigned char *ser_blockheader(unsigned char *dest, BlockHeader *block_header){
   memcpy(dest, &(block_header->timestamp), sizeof(block_header->timestamp));
 
-  char *all_tx = dest + sizeof(block_header->timestamp);
+  unsigned char *all_tx = dest + sizeof(block_header->timestamp);
   memcpy(all_tx, &(block_header->all_tx), sizeof(block_header->all_tx));
 
-  char *prev_header_hash = all_tx + sizeof(block_header->all_tx);
+  unsigned char *prev_header_hash = all_tx + sizeof(block_header->all_tx);
   memcpy(prev_header_hash, &(block_header->prev_header_hash), sizeof(block_header->prev_header_hash));
 
-  char *nonce = prev_header_hash + sizeof(block_header->prev_header_hash);
+  unsigned char *nonce = prev_header_hash + sizeof(block_header->prev_header_hash);
   memcpy(nonce, &(block_header->nonce), sizeof(block_header->nonce));
 
-  char* terminate = nonce+sizeof(block_header->nonce);
+  unsigned char* terminate = nonce+sizeof(block_header->nonce);
   return terminate;
 }
 
-char *ser_blockheader_alloc(BlockHeader *block_header){
-  char *data = malloc(sizeof(BlockHeader));
+unsigned char *ser_blockheader_alloc(BlockHeader *block_header){
+  unsigned char *data = malloc(sizeof(BlockHeader));
   ser_blockheader(data, block_header);
   return data;
 }
 
 void hash_blockheader(BlockHeader *header, unsigned char *buf) {
-  char *header_buf;
+  unsigned char *header_buf;
   header_buf = ser_blockheader_alloc(header);
   hash_sha256(buf, header_buf, sizeof(BlockHeader));
   free(header_buf);
@@ -41,21 +41,21 @@ int size_block(Block *block){
   return size;
 }
 
-char *ser_block(char *dest, Block *block){
-  memcpy(dest, block->num_txs, sizeof(block->num_txs));
+unsigned char *ser_block(unsigned char *dest, Block *block){
+  memcpy(dest, &(block->num_txs), sizeof(block->num_txs));
 
-  char *block_header = dest + sizeof(block->num_txs);
-  char *txs = ser_blockheader(&(block->header), block_header);
+  unsigned char *block_header = dest + sizeof(block->num_txs);
+  unsigned char *txs = ser_blockheader(block_header, &(block->header));
 
   for(int i = 0; i < block->num_txs; i++){
-      char *txs = ser_tx(&(block->txs[i]), txs);
+      unsigned char *txs = ser_tx(txs, &(block->txs[i]));
   }
-  char *end = txs;
+  unsigned char *end = txs;
   return end;
 }
 
-char *ser_block_alloc(Block *block){
-  char *data = malloc(size_block(block));
+unsigned char *ser_block_alloc(Block *block){
+  unsigned char *data = malloc(size_block(block));
   ser_block(data, block);
   return data;
 }

--- a/src/core/blocks/base_block.c
+++ b/src/core/blocks/base_block.c
@@ -26,6 +26,13 @@ char *ser_blockheader_alloc(BlockHeader *block_header){
   return data;
 }
 
+void hash_blockheader(BlockHeader *header, unsigned char *buf) {
+  char *header_buf;
+  header_buf = ser_blockheader_alloc(header);
+  hash_sha256(buf, header_buf, sizeof(BlockHeader));
+  free(header_buf);
+}
+
 int size_block(Block *block){
   int size = (sizeof(block->num_txs) + sizeof(block->header));
   for(int i = 0; i < block->num_txs; i++){

--- a/src/core/blocks/base_block.c
+++ b/src/core/blocks/base_block.c
@@ -53,6 +53,7 @@ char *ser_block(char *dest, Block *block){
   char *end = txs;
   return end;
 }
+
 char *ser_block_alloc(Block *block){
   char *data = malloc(size_block(block));
   ser_block(data, block);

--- a/src/core/globals/blockchain.c
+++ b/src/core/globals/blockchain.c
@@ -1,0 +1,53 @@
+#include "blockchain.h"
+
+void blockchain_init() {
+  blockchain = NULL;
+}
+
+Block *blockchain_add(Block *block) {
+  BlockChain *new_entry, *found_entry;
+
+  new_entry = malloc(sizeof(BlockChain));
+  hash_blockheader(&(block->header), new_entry->id);
+  new_entry->block = block;
+
+  found_entry = blockchain_find_node(new_entry->id);
+  if (found_entry == NULL) {
+    HASH_ADD(hh, blockchain, id, TX_HASH_LEN, new_entry);
+    return block;
+  }
+  free(new_entry);
+  return NULL;
+}
+
+Block *blockchain_remove(unsigned char *header_hash) {
+  BlockChain *entry;
+  Block *block;
+
+  entry = blockchain_find_node(header_hash);
+  if (entry != NULL) {
+    block = entry->block;
+    HASH_DEL(blockchain, entry);
+    free(entry);
+    return block;
+  }
+
+  return NULL;
+}
+
+Block *blockchain_find(unsigned char *header_hash) {
+  BlockChain *found_entry;
+
+  found_entry = blockchain_find_node(header_hash);
+  if (found_entry != NULL) {
+    return found_entry->block;
+  }
+
+  return NULL;
+}
+
+BlockChain *blockchain_find_node(unsigned char *header_hash) {
+  BlockChain *found_entry;
+  HASH_FIND(hh, blockchain, header_hash, BLOCK_HASH_LEN, found_entry);
+  return found_entry;
+}

--- a/src/core/globals/blockchain.c
+++ b/src/core/globals/blockchain.c
@@ -1,7 +1,22 @@
 #include "blockchain.h"
 
 void blockchain_init() {
-  blockchain = NULL;
+  Block* genesis_block;
+
+  blockchain = NULL;  // Must always start at NULL
+
+  genesis_block = malloc(sizeof(Block));
+
+  // Initialize with a totally empty block
+  genesis_block->num_txs = 0;
+  genesis_block->txs = NULL;
+
+  genesis_block->header.timestamp = 0;
+  genesis_block->header.nonce = 0;
+  memset(&(genesis_block->header.all_tx), 0, TX_HASH_LEN);
+  memset(&(genesis_block->header.prev_header_hash), 0, BLOCK_HASH_LEN);
+
+  blockchain_add(genesis_block);
 }
 
 Block *blockchain_add(Block *block) {

--- a/src/core/globals/blockchain.c
+++ b/src/core/globals/blockchain.c
@@ -23,7 +23,7 @@ Block *blockchain_add(Block *block) {
   BlockChain *new_entry, *found_entry;
 
   new_entry = malloc(sizeof(BlockChain));
-  hash_blockheader(&(block->header), new_entry->id);
+  hash_blockheader(new_entry->id, &(block->header));
   new_entry->block = block;
 
   found_entry = blockchain_find_node(new_entry->id);

--- a/src/core/globals/constants.c
+++ b/src/core/globals/constants.c
@@ -3,7 +3,7 @@
 #include <constants.h>
 
 // TODO: Actually implelement.
-int hash_sha256(unsigned char * output_hash, char * input_data, unsigned int input_sz){
+int hash_sha256(unsigned char * output_hash, unsigned char * input_data, unsigned int input_sz){
   memcpy(output_hash, input_data, TX_HASH_LEN);
   return 1;
 }

--- a/src/core/globals/mempool.c
+++ b/src/core/globals/mempool.c
@@ -8,7 +8,7 @@ Transaction *mempool_add(Transaction *tx) {
   MemPool *new_entry, *found_entry;
 
   new_entry = malloc(sizeof(MemPool));
-  hash_tx(tx, new_entry->id);
+  hash_tx(new_entry->id, tx);
   new_entry->tx = tx;
 
   found_entry = mempool_find_node(new_entry->id);

--- a/src/core/globals/mempool.c
+++ b/src/core/globals/mempool.c
@@ -7,6 +7,7 @@ void mempool_init() {
 Transaction *mempool_add(Transaction *tx) {
   MemPool *new_entry, *found_entry;
 
+  new_entry = malloc(sizeof(MemPool));
   hash_tx(tx, new_entry->id);
   new_entry->tx = tx;
 
@@ -19,32 +20,29 @@ Transaction *mempool_add(Transaction *tx) {
   return NULL;
 }
 
-Transaction *mempool_remove(Transaction *tx) {
+Transaction *mempool_remove(unsigned char *tx_hash) {
   MemPool *entry;
-  char *tx_buf;
-  int tx_buf_size;
-  unsigned char buf[TX_HASH_LEN];
+  Transaction *tx;
 
-  hash_tx(tx, buf);
-  entry = mempool_find_node(buf);
-
+  entry = mempool_find_node(tx_hash);
   if (entry != NULL) {
+    tx = entry->tx;
     HASH_DEL(mempool, entry);
     free(entry);
     return tx;
   }
+
   return NULL;
 }
 
-Transaction *mempool_find(Transaction *tx) {
+Transaction *mempool_find(unsigned char *tx_hash) {
   MemPool *found_entry;
-  unsigned char buf[TX_HASH_LEN];
 
-  hash_tx(tx, buf);
-  found_entry = mempool_find_node(buf);
+  found_entry = mempool_find_node(tx_hash);
   if (found_entry != NULL) {
     return found_entry->tx;
   }
+
   return NULL;
 }
 

--- a/src/core/globals/mempool.c
+++ b/src/core/globals/mempool.c
@@ -4,39 +4,51 @@ void mempool_init() {
   mempool = NULL;
 }
 
-Transaction* mempool_add(Transaction *tx) {
+Transaction *mempool_add(Transaction *tx) {
   MemPool *new_entry, *found_entry;
 
-  new_entry = malloc(sizeof(MemPool));
   hash_tx(tx, new_entry->id);
   new_entry->tx = tx;
 
-  found_entry = mempool_find(new_entry->id);
+  found_entry = mempool_find_node(new_entry->id);
   if (found_entry == NULL) {
     HASH_ADD(hh, mempool, id, TX_HASH_LEN, new_entry);
     return tx;
-  } else {
-    // In practice this should never happen
-    free(new_entry);
-    return NULL;
   }
+  free(new_entry);
+  return NULL;
 }
 
-Transaction* mempool_remove(Transaction *tx) {
+Transaction *mempool_remove(Transaction *tx) {
   MemPool *entry;
+  char *tx_buf;
+  int tx_buf_size;
   unsigned char buf[TX_HASH_LEN];
 
   hash_tx(tx, buf);
-  entry = mempool_find(buf);
+  entry = mempool_find_node(buf);
 
   if (entry != NULL) {
     HASH_DEL(mempool, entry);
+    free(entry);
     return tx;
   }
   return NULL;
 }
 
-MemPool* mempool_find(unsigned char *tx_hash) {
+Transaction *mempool_find(Transaction *tx) {
+  MemPool *found_entry;
+  unsigned char buf[TX_HASH_LEN];
+
+  hash_tx(tx, buf);
+  found_entry = mempool_find_node(buf);
+  if (found_entry != NULL) {
+    return found_entry->tx;
+  }
+  return NULL;
+}
+
+MemPool *mempool_find_node(unsigned char *tx_hash) {
   MemPool *found_entry;
   HASH_FIND(hh, mempool, tx_hash, TX_HASH_LEN, found_entry);
   return found_entry;

--- a/src/core/globals/utxo_pool.c
+++ b/src/core/globals/utxo_pool.c
@@ -1,0 +1,77 @@
+#include "utxo_pool.h"
+
+void utxo_pool_init() {
+  utxo_pool = NULL;
+}
+
+UTXO *utxo_pool_add(Transaction *tx, unsigned int vout) {
+  UTXOPool *new_entry, *found_entry;
+  UTXO *utxo;
+
+  new_entry = malloc(sizeof(UTXOPool));
+
+  // Build key
+  memset(&(new_entry->id), 0, sizeof(UTXOPoolKey));
+  hash_tx(tx, new_entry->id.tx_hash);
+  new_entry->id.vout = vout;
+
+  // Build new UTXO
+  utxo = malloc(sizeof(UTXO));
+  utxo->amt = tx->outputs[vout].amt;
+  memcpy(utxo->public_key_hash, tx->outputs[vout].public_key_hash, LOCK_SCRIPT_LEN);
+  utxo->spent = 0;
+
+  new_entry->utxo = utxo;
+
+  found_entry = utxo_pool_find_node_key(&(new_entry->id));
+  if (found_entry == NULL) {
+    HASH_ADD(hh, utxo_pool, id, sizeof(UTXOPoolKey), new_entry);
+    return utxo;
+  } else {
+    free(new_entry->utxo);
+    free(new_entry);
+    return NULL;
+  }
+}
+
+UTXO *utxo_pool_remove(unsigned char *tx_hash, unsigned int vout) {
+  UTXOPool *entry;
+  UTXO *utxo;
+
+  entry = utxo_pool_find_node(tx_hash, vout);
+  if (entry != NULL) {
+    utxo = entry->utxo;
+    HASH_DEL(utxo_pool, entry);
+    free(entry);
+    return utxo;
+  }
+
+  return NULL;
+}
+
+UTXO *utxo_pool_find(unsigned char *tx_hash, unsigned int vout) {
+  UTXOPool *found_entry;
+
+  found_entry = utxo_pool_find_node(tx_hash, vout);
+  if (found_entry != NULL) {
+    return found_entry->utxo;
+  }
+
+  return NULL;
+}
+
+UTXOPool *utxo_pool_find_node(unsigned char *tx_hash, unsigned int vout) {
+  UTXOPoolKey key;
+
+  memset(&key, 0, sizeof(UTXOPoolKey));
+  memcpy(key.tx_hash, tx_hash, TX_HASH_LEN);
+  key.vout = vout;
+
+  return utxo_pool_find_node_key(&key);
+}
+
+UTXOPool *utxo_pool_find_node_key(UTXOPoolKey *key) {
+  UTXOPool *found_entry;
+  HASH_FIND(hh, utxo_pool, key, sizeof(UTXOPoolKey), found_entry);
+  return found_entry;
+}

--- a/src/core/globals/utxo_pool.c
+++ b/src/core/globals/utxo_pool.c
@@ -12,7 +12,7 @@ UTXO *utxo_pool_add(Transaction *tx, unsigned int vout) {
 
   // Build key
   memset(&(new_entry->id), 0, sizeof(UTXOPoolKey));
-  hash_tx(tx, new_entry->id.tx_hash);
+  hash_tx(new_entry->id.tx_hash, tx);
   new_entry->id.vout = vout;
 
   // Build new UTXO

--- a/src/core/txs/base_tx.c
+++ b/src/core/txs/base_tx.c
@@ -4,29 +4,29 @@
 
 #include "base_tx.h"
 
-char *ser_utxo(UTXO *utxo){
-  char *data = malloc(sizeof(UTXO));
+unsigned char *ser_utxo(UTXO *utxo){
+  unsigned char *data = malloc(sizeof(UTXO));
   memcpy(data, &(utxo->amt), sizeof(utxo->amt));
 
-  char *sig = data + sizeof(utxo->amt);
+  unsigned char *sig = data + sizeof(utxo->amt);
   memcpy(sig, &(utxo->public_key_hash), sizeof(utxo->public_key_hash));
 
-  char *spent = sig + sizeof(utxo->public_key_hash);
+  unsigned char *spent = sig + sizeof(utxo->public_key_hash);
   memcpy(spent, &(utxo->spent), sizeof(utxo->spent));
 
   return data;
 }
 
-UTXO *dser_utxo(char *data){
+UTXO *dser_utxo(unsigned char *data){
   UTXO *new_UTXO = malloc(sizeof(UTXO));
 
   // Stolen from https://cboard.cprogramming.com/cplusplus-programming/43180-sizeof-struct-member-problem.html
   memcpy(&(new_UTXO->amt), data, sizeof(((UTXO*)0)->amt));
 
-  char *sig = data + sizeof(((UTXO*)0)->amt);
+  unsigned char *sig = data + sizeof(((UTXO*)0)->amt);
   memcpy(&(new_UTXO->public_key_hash), sig, sizeof(((UTXO*)0)->public_key_hash));
 
-  char *spent = sig + sizeof(((UTXO*)0)->public_key_hash);
+  unsigned char *spent = sig + sizeof(((UTXO*)0)->public_key_hash);
   memcpy(&(new_UTXO->spent), spent, sizeof(((UTXO*)0)->spent));
 
   return new_UTXO;
@@ -37,43 +37,43 @@ int size_tx(Transaction *tx){
     tx->num_inputs * sizeof(Input) + tx->num_outputs * sizeof(Output));
 }
 
-char *ser_tx( char *dest, Transaction *tx){
+unsigned char *ser_tx(unsigned char *dest, Transaction *tx){
   memcpy(dest, &(tx->num_inputs), sizeof(tx->num_inputs));
 
-  char *num_outputs = dest + sizeof(tx->num_inputs);
+  unsigned char *num_outputs = dest + sizeof(tx->num_inputs);
   memcpy(num_outputs, &(tx->num_outputs), sizeof(tx->num_outputs));
 
-  char *inputs = num_outputs + sizeof(tx->num_outputs);
+  unsigned char *inputs = num_outputs + sizeof(tx->num_outputs);
   memcpy(inputs, tx->inputs, tx->num_inputs * sizeof(Input));
 
-  char *outputs = inputs + tx->num_inputs * sizeof(Input);
+  unsigned char *outputs = inputs + tx->num_inputs * sizeof(Input);
   memcpy(outputs, tx->outputs, tx->num_outputs * sizeof(Output));
 
-  char * end = outputs + tx->num_outputs * sizeof(Output);
+  unsigned char * end = outputs + tx->num_outputs * sizeof(Output);
   return end;
 }
 
-char *ser_tx_alloc(Transaction *tx){
-  char *data = malloc(size_tx(tx));
+unsigned char *ser_tx_alloc(Transaction *tx){
+  unsigned char *data = malloc(size_tx(tx));
   ser_tx(data, tx);
   return data;
 }
 
-Transaction *deser_tx(char *data){
+Transaction *deser_tx(unsigned char *data){
   Transaction *new_tx = malloc(sizeof(Transaction));
 
   memcpy(&(new_tx->num_inputs), data, sizeof(int));
 
-  char *nm_outputs = data + sizeof(int);
+  unsigned char *nm_outputs = data + sizeof(int);
   memcpy(&(new_tx->num_outputs), nm_outputs, sizeof(int));
 
-  char *inputs = nm_outputs + sizeof(int);
-  int input_sz = new_tx->num_inputs * sizeof(Input);
+  unsigned char *inputs = nm_outputs + sizeof(int);
+  unsigned int input_sz = new_tx->num_inputs * sizeof(Input);
   new_tx->inputs = malloc(input_sz);
   memcpy(new_tx->inputs, inputs, input_sz);
 
-  char *outputs = inputs + input_sz;
-  int output_sz = new_tx->num_outputs * sizeof(Output);
+  unsigned char *outputs = inputs + input_sz;
+  unsigned int output_sz = new_tx->num_outputs * sizeof(Output);
   new_tx->outputs = malloc(output_sz);
   memcpy(new_tx->outputs, outputs, output_sz);
 
@@ -81,7 +81,7 @@ Transaction *deser_tx(char *data){
 }
 
 void hash_tx(Transaction *tx, unsigned char *buf) {
-  char *tx_buf;
+  unsigned char *tx_buf;
   int tx_buf_size;
 
   tx_buf_size = size_tx(tx);

--- a/src/core/txs/base_tx.c
+++ b/src/core/txs/base_tx.c
@@ -114,6 +114,16 @@ Transaction* deser_tx(char *data){
   return new_tx;
 }
 
+void hash_tx(Transaction *tx, unsigned char *buf) {
+  char *tx_buf;
+  int tx_buf_size;
+
+  tx_buf_size = size_tx(tx);
+  tx_buf = ser_tx_alloc(tx);
+  hash_sha256(buf, tx_buf, tx_buf_size);
+  free(tx_buf);
+}
+
 void print_input(Input *input){
   printf("\nInput Data:\n");
   printf("sig: %s\n", input->signature);

--- a/src/core/txs/base_tx.c
+++ b/src/core/txs/base_tx.c
@@ -80,13 +80,13 @@ Transaction *deser_tx(unsigned char *data){
   return new_tx;
 }
 
-void hash_tx(Transaction *tx, unsigned char *buf) {
+void hash_tx(unsigned char *dest, Transaction *tx) {
   unsigned char *tx_buf;
   int tx_buf_size;
 
   tx_buf_size = size_tx(tx);
   tx_buf = ser_tx_alloc(tx);
-  hash_sha256(buf, tx_buf, tx_buf_size);
+  hash_sha256(dest, tx_buf, tx_buf_size);
   free(tx_buf);
 }
 

--- a/src/core/txs/base_tx.c
+++ b/src/core/txs/base_tx.c
@@ -9,9 +9,9 @@ char *ser_utxo(UTXO *utxo){
   memcpy(data, &(utxo->amt), sizeof(utxo->amt));
 
   char *sig = data + sizeof(utxo->amt);
-  memcpy(sig, &(utxo->signature), sizeof(utxo->signature));
+  memcpy(sig, &(utxo->public_key_hash), sizeof(utxo->public_key_hash));
 
-  char *spent = sig + sizeof(utxo->signature);
+  char *spent = sig + sizeof(utxo->public_key_hash);
   memcpy(spent, &(utxo->spent), sizeof(utxo->spent));
 
   return data;
@@ -24,9 +24,9 @@ UTXO *dser_utxo(char *data){
   memcpy(&(new_UTXO->amt), data, sizeof(((UTXO*)0)->amt));
 
   char *sig = data + sizeof(((UTXO*)0)->amt);
-  memcpy(&(new_UTXO->signature), sig, sizeof(((UTXO*)0)->signature));
+  memcpy(&(new_UTXO->public_key_hash), sig, sizeof(((UTXO*)0)->public_key_hash));
 
-  char *spent = sig + sizeof(((UTXO*)0)->signature);
+  char *spent = sig + sizeof(((UTXO*)0)->public_key_hash);
   memcpy(&(new_UTXO->spent), spent, sizeof(((UTXO*)0)->spent));
 
   return new_UTXO;

--- a/src/includes/blocks/base_block.h
+++ b/src/includes/blocks/base_block.h
@@ -21,6 +21,7 @@ typedef struct Block{
 
 char *ser_blockheader(char *dest, BlockHeader *block_header);
 char *ser_blockheader_alloc(BlockHeader *block_header);
+void hash_blockheader(BlockHeader *header, unsigned char *buf);
 
 int size_block(Block *Block);
 char *ser_block(char *dest, Block *block);

--- a/src/includes/blocks/base_block.h
+++ b/src/includes/blocks/base_block.h
@@ -21,7 +21,7 @@ typedef struct Block{
 
 unsigned char *ser_blockheader(unsigned char *dest, BlockHeader *block_header);
 unsigned char *ser_blockheader_alloc(BlockHeader *block_header);
-void hash_blockheader(BlockHeader *header, unsigned char *buf);
+void hash_blockheader(unsigned char *dest, BlockHeader *header);
 
 int size_block(Block *Block);
 unsigned char *ser_block(unsigned char *dest, Block *block);

--- a/src/includes/blocks/base_block.h
+++ b/src/includes/blocks/base_block.h
@@ -21,6 +21,12 @@ typedef struct Block{
 
 unsigned char *ser_blockheader(unsigned char *dest, BlockHeader *block_header);
 unsigned char *ser_blockheader_alloc(BlockHeader *block_header);
+
+/* Hashes passed block header
+ *
+ * dest: Buffer to write hash to, expected to be of size BLOCK_HASH_LEN
+ * header: Block header to hash
+ */
 void hash_blockheader(unsigned char *dest, BlockHeader *header);
 
 int size_block(Block *Block);

--- a/src/includes/blocks/base_block.h
+++ b/src/includes/blocks/base_block.h
@@ -19,10 +19,10 @@ typedef struct Block{
 
 #endif
 
-char *ser_blockheader(char *dest, BlockHeader *block_header);
-char *ser_blockheader_alloc(BlockHeader *block_header);
+unsigned char *ser_blockheader(unsigned char *dest, BlockHeader *block_header);
+unsigned char *ser_blockheader_alloc(BlockHeader *block_header);
 void hash_blockheader(BlockHeader *header, unsigned char *buf);
 
 int size_block(Block *Block);
-char *ser_block(char *dest, Block *block);
-char *ser_block_alloc(Block *block);
+unsigned char *ser_block(unsigned char *dest, Block *block);
+unsigned char *ser_block_alloc(Block *block);

--- a/src/includes/globals/blockchain.h
+++ b/src/includes/globals/blockchain.h
@@ -17,15 +17,16 @@ void blockchain_init();
 
 /* Creates a new entry in the hashmap with the passed block
  *
- * Returns the pointer to passed block if node created, NULL otherwise
+ * Returns passed block pointer if entry created, NULL otherwise
  *
- * block: Pointer to block that will be stored in entry
+ * block: Block pointer that will be stored in entry
  */
 Block *blockchain_add(Block *block);
 
 /* Removes the entry corresponding to header_hash
  *
- * Returns the block stored in removed entry if succesfully removed, NULL otherwise
+ * Returns the block pointer stored in removed entry if succesfully removed,
+ * NULL otherwise
  *
  * header_hash: Buffer of length BLOCK_HASH_LEN, hash of block header
  */
@@ -33,7 +34,7 @@ Block *blockchain_remove(unsigned char *header_hash);
 
 /* Finds block corresponding to header_hash
  *
- * Returns block if found, NULL otherwise
+ * Returns block pointer if found, NULL otherwise
  *
  * header_hash: Buffer of length BLOCK_HASH_LEN, hash of block header
  */

--- a/src/includes/globals/blockchain.h
+++ b/src/includes/globals/blockchain.h
@@ -6,7 +6,14 @@
 
 typedef struct BlockChain {
   unsigned char id[BLOCK_HASH_LEN];
-  Block block;
+  Block *block;
+  UT_hash_handle hh;
 } BlockChain;
 
 BlockChain *blockchain;
+
+void blockchain_init();
+Block *blockchain_add(Block *block);
+Block *blockchain_remove(unsigned char *header_hash);
+Block *blockchain_find(unsigned char *header_hash);
+BlockChain *blockchain_find_node(unsigned char *header_hash);

--- a/src/includes/globals/blockchain.h
+++ b/src/includes/globals/blockchain.h
@@ -12,8 +12,38 @@ typedef struct BlockChain {
 
 BlockChain *blockchain;
 
+/* Initializes the global blockchain variable */
 void blockchain_init();
+
+/* Creates a new entry in the hashmap with the passed block
+ *
+ * Returns the pointer to passed block if node created, NULL otherwise
+ *
+ * block: Pointer to block that will be stored in entry
+ */
 Block *blockchain_add(Block *block);
+
+/* Removes the entry corresponding to header_hash
+ *
+ * Returns the block stored in removed entry if succesfully removed, NULL otherwise
+ *
+ * header_hash: Buffer of length BLOCK_HASH_LEN, hash of block header
+ */
 Block *blockchain_remove(unsigned char *header_hash);
+
+/* Finds block corresponding to header_hash
+ *
+ * Returns block if found, NULL otherwise
+ *
+ * header_hash: Buffer of length BLOCK_HASH_LEN, hash of block header
+ */
 Block *blockchain_find(unsigned char *header_hash);
+
+
+/* Finds entry corresponding to header_hash
+ *
+ * Returns entry if found, NULL otherwise
+ *
+ * header_hash: Buffer of length BLOCK_HASH_LEN, hash of block header
+ */
 BlockChain *blockchain_find_node(unsigned char *header_hash);

--- a/src/includes/globals/constants.h
+++ b/src/includes/globals/constants.h
@@ -10,4 +10,4 @@
  input_sz: number of bytes in input
  output_hash: unsigned * of size TX_HASH_LEN
  */
-int hash_sha256(unsigned char * output_hash, char * input_data, unsigned int input_sz); 
+int hash_sha256(unsigned char * output_hash, unsigned char * input_data, unsigned int input_sz); 

--- a/src/includes/globals/mempool.h
+++ b/src/includes/globals/mempool.h
@@ -14,6 +14,6 @@ MemPool *mempool;
 
 void mempool_init();
 Transaction *mempool_add(Transaction *tx);
-Transaction *mempool_remove(Transaction *tx);
-Transaction *mempool_find(Transaction *tx);
+Transaction *mempool_remove(unsigned char *tx_hash);
+Transaction *mempool_find(unsigned char *tx_hash);
 MemPool *mempool_find_node(unsigned char *tx_hash);

--- a/src/includes/globals/mempool.h
+++ b/src/includes/globals/mempool.h
@@ -1,5 +1,4 @@
-#ifndef MEMPOOL_H
-#define MEMPOOL_H
+#pragma 1
 
 #include "constants.h"
 #include "uthash.h"
@@ -14,8 +13,7 @@ typedef struct MemPool {
 MemPool *mempool;
 
 void mempool_init();
-Transaction* mempool_add(Transaction *tx);
-Transaction* mempool_remove(Transaction *tx);
-MemPool* mempool_find(unsigned char *tx_hash);
-
-#endif
+Transaction *mempool_add(Transaction *tx);
+Transaction *mempool_remove(Transaction *tx);
+Transaction *mempool_find(Transaction *tx);
+MemPool *mempool_find_node(unsigned char *tx_hash);

--- a/src/includes/globals/mempool.h
+++ b/src/includes/globals/mempool.h
@@ -12,8 +12,38 @@ typedef struct MemPool {
 
 MemPool *mempool;
 
+/* Initializes the global mempool variable */
 void mempool_init();
+
+/* Creates a new entry in the hashmap with the passed transaction
+ *
+ * Returns passed transaction pointer if entry created, NULL otherwise
+ *
+ * transaction: Transaction pointer that will be stored in entry
+ */
 Transaction *mempool_add(Transaction *tx);
+
+/* Removes the entry corresponding to tx_hash
+ *
+ * Returns the transaction pointer stored in removed entry if succesfully
+ * removed, NULL otherwise
+ *
+ * tx_hash: Buffer of length TX_HASH_LEN, hash of transaction
+ */
 Transaction *mempool_remove(unsigned char *tx_hash);
+
+/* Finds transaction corresponding to tx_hash
+ *
+ * Returns transaction pointer if found, NULL otherwise
+ *
+ * tx_hash: Buffer of length TX_HASH_LEN, hash of transaction
+ */
 Transaction *mempool_find(unsigned char *tx_hash);
+
+/* Finds entry corresponding to tx_hash
+ *
+ * Returns entry if found, NULL otherwise
+ *
+ * tx_hash: Buffer of length TX_HASH_LEN, hash of transaction
+ */
 MemPool *mempool_find_node(unsigned char *tx_hash);

--- a/src/includes/globals/utxo_pool.h
+++ b/src/includes/globals/utxo_pool.h
@@ -17,10 +17,63 @@ typedef struct UTXOPool {
 
 UTXOPool *utxo_pool;
 
+/* Initializes the global utxo_pool variable */
 void utxo_pool_init();
+
+/* Creates a new UTXO using transaction and output number, then ceates a new
+ * entry in the hashmap
+ * 
+ * Returns pointer to newly created UTXO if entry created, NULL otherwise
+ *
+ * transaction: Transaction pointer to transaction the new UTXO is an output of
+ * vout: Which output of the passed transaction the new UTXO is
+ */
 UTXO *utxo_pool_add(Transaction *tx, unsigned int vout);
+
+/* Removes the entry corresponding to transaction hash and output number
+ *
+ * Returns the UTXO pointer stored in removed entry if succesfully removed, NULL
+ * otherwise
+ *
+ * tx_hash: Buffer of length TX_HASH_LEN, hash of transaction the UTXO is from
+ * vout: Which output of the transaction the UTXO is from
+ */
 UTXO *utxo_pool_remove(unsigned char *tx_hash, unsigned int vout);
+
+/* Removes the entry corresponding to UTXOPoolKey. Same behavior as
+ * utxo_pool_remove, but takes UTXOPoolKey instead. Primary an internal func
+ *
+ * Returns the UTXO pointer stored in removed entry if succesfully removed, NULL
+ * otherwise
+ *
+ * key: UTXOPoolKey struct containing tx_hash and vout to query for
+ */
 UTXO *utxo_pool_remove_key(UTXOPoolKey *key);
+
+/* Finds UTXO corresponding to transaction hash and output number
+ *
+ * Returns UTXO pointer if found, NULL otherwise
+ *
+ * tx_hash: Buffer of length TX_HASH_LEN, hash of transaction the UTXO is from
+ * vout: Which output of the transaction the UTXO is from
+ */
 UTXO *utxo_pool_find(unsigned char *tx_hash, unsigned int vout);
+
+/* Finds entry corresponding to transaction hash and output number
+ *
+ * Returns entry if found, NULL otherwise
+ *
+ * tx_hash: Buffer of length TX_HASH_LEN, hash of transaction the UTXO is from
+ * vout: Which output of the transaction the UTXO is from
+ */
 UTXOPool *utxo_pool_find_node(unsigned char *tx_hash, unsigned int vout);
+
+/* Finds entry corresponding to UTXOPoolKey. Same behavior as
+ * utxo_pool_find_node, but takes UTXOPoolKey instead. Primarily an internal
+ * func
+ *
+ * Returns entry if found, NULL otherwise
+ *
+ * key: UTXOPoolKey struct containing tx_hash and vout to query for
+ */
 UTXOPool *utxo_pool_find_node_key(UTXOPoolKey *key);

--- a/src/includes/globals/utxo_pool.h
+++ b/src/includes/globals/utxo_pool.h
@@ -1,5 +1,4 @@
-#ifndef UTXO_POOL_H
-#define UTXO_POOL_H
+#pragma 1
 
 #include "constants.h"
 #include "uthash.h"
@@ -12,10 +11,16 @@ typedef struct UTXOPoolKey {
 
 typedef struct UTXOPool {
     UTXOPoolKey id;
-    UTXO utxo;
+    UTXO *utxo;
     UT_hash_handle hh;
 } UTXOPool;
 
 UTXOPool *utxo_pool;
 
-#endif
+void utxo_pool_init();
+UTXO *utxo_pool_add(Transaction *tx, unsigned int vout);
+UTXO *utxo_pool_remove(unsigned char *tx_hash, unsigned int vout);
+UTXO *utxo_pool_remove_key(UTXOPoolKey *key);
+UTXO *utxo_pool_find(unsigned char *tx_hash, unsigned int vout);
+UTXOPool *utxo_pool_find_node(unsigned char *tx_hash, unsigned int vout);
+UTXOPool *utxo_pool_find_node_key(UTXOPoolKey *key);

--- a/src/includes/txs/base_tx.h
+++ b/src/includes/txs/base_tx.h
@@ -11,14 +11,14 @@ typedef struct Output{
 } Output;
 
 typedef struct Input{
-  char signature[SIGNATURE_LEN];
+  unsigned char signature[SIGNATURE_LEN];
   unsigned char prev_tx_id[TX_HASH_LEN];
-  int prev_utxo_output;
+  unsigned int prev_utxo_output;
 } Input; 
 
 typedef struct Transaction{
-  int num_inputs;
-  int num_outputs;
+  unsigned int num_inputs;
+  unsigned int num_outputs;
   Input *inputs;
   Output *outputs;
 } Transaction;
@@ -29,17 +29,17 @@ typedef struct UTXO{
   short spent;
 } UTXO;
 
-char *ser_utxo(UTXO *utxo);
-UTXO *dser_utxo(char *data);
+unsigned char *ser_utxo(UTXO *utxo);
+UTXO *dser_utxo(unsigned char *data);
 
 /*
 Return Size of a transaction, used for serialization and memory allocation
 */
 int size_tx(Transaction *tx);
 
-char *ser_tx(char *dest, Transaction *tx);
-char *ser_tx_alloc(Transaction *tx);
-Transaction* deser_tx(char *data);
+unsigned char *ser_tx(unsigned char *dest, Transaction *tx);
+unsigned char *ser_tx_alloc(Transaction *tx);
+Transaction* deser_tx(unsigned char *data);
 void hash_tx(Transaction *tx, unsigned char *buf);
 
 void print_input(Input *input);

--- a/src/includes/txs/base_tx.h
+++ b/src/includes/txs/base_tx.h
@@ -40,7 +40,7 @@ int size_tx(Transaction *tx);
 unsigned char *ser_tx(unsigned char *dest, Transaction *tx);
 unsigned char *ser_tx_alloc(Transaction *tx);
 Transaction* deser_tx(unsigned char *data);
-void hash_tx(Transaction *tx, unsigned char *buf);
+void hash_tx(unsigned char *dest, Transaction *tx);
 
 void print_input(Input *input);
 void print_output(Output *output);

--- a/src/includes/txs/base_tx.h
+++ b/src/includes/txs/base_tx.h
@@ -26,7 +26,7 @@ typedef struct Transaction{
 
 typedef struct UTXO{
     unsigned long amt;
-    char signature[SIGNATURE_LEN];
+    unsigned char public_key_hash[LOCK_SCRIPT_LEN];
     short spent;
 } UTXO;
 

--- a/src/includes/txs/base_tx.h
+++ b/src/includes/txs/base_tx.h
@@ -40,6 +40,12 @@ int size_tx(Transaction *tx);
 unsigned char *ser_tx(unsigned char *dest, Transaction *tx);
 unsigned char *ser_tx_alloc(Transaction *tx);
 Transaction* deser_tx(unsigned char *data);
+
+/* Hashes passed transaction
+ *
+ * dest: Buffer to write hash to, expected to be of size TX_HASH_LEN
+ * tx: Transaction to hash
+ */
 void hash_tx(unsigned char *dest, Transaction *tx);
 
 void print_input(Input *input);

--- a/src/tests/core/txs/test_base_tx.c
+++ b/src/tests/core/txs/test_base_tx.c
@@ -8,7 +8,7 @@
 int main() {
   Output *an_Output = malloc(sizeof(Output));
   an_Output->amt = 5;
-  strcpy(an_Output->public_key_hash, "a_val");
+  strcpy((char*)an_Output->public_key_hash, "a_val");
 
   Input *an_Input = malloc(sizeof(Input));
   an_Input->prev_utxo_output = 2;
@@ -41,7 +41,7 @@ int main() {
   // //printf("prev_tx_id: %s\n", ((a_Tx->inputs)+1)->prev_tx_id);
 
   //Serialization Testing
-  char *char_tx = ser_tx_alloc(a_Tx);
+  unsigned char *char_tx = ser_tx_alloc(a_Tx);
 
   Transaction *other_tx = deser_tx(char_tx);
 


### PR DESCRIPTION
Adds helper functions for all hashmap datastructures we are using. Also adds helper hashing functions for block headers and transactions.

Some notes
* What should be passed and returned from these functions is still up in the air. I took some guesses as to how we're going to use these, but they are definitely open to change if another signature ends up being more convenient.
* The mempool datastructure is probably not what it should be. Will be converted to a heap at some point in the future, assuming we truly have to use cases where querying is necessary.