### PR TITLE
Standardize to unsigned char and unsigned int

### DIFF
--- a/src/core/blocks/base_block.c
+++ b/src/core/blocks/base_block.c
@@ -4,30 +4,30 @@
 
 #include "base_block.h"
 
-char *ser_blockheader(char *dest, BlockHeader *block_header){
+unsigned char *ser_blockheader(unsigned char *dest, BlockHeader *block_header){
   memcpy(dest, &(block_header->timestamp), sizeof(block_header->timestamp));
 
-  char *all_tx = dest + sizeof(block_header->timestamp);
+  unsigned char *all_tx = dest + sizeof(block_header->timestamp);
   memcpy(all_tx, &(block_header->all_tx), sizeof(block_header->all_tx));
 
-  char *prev_header_hash = all_tx + sizeof(block_header->all_tx);
+  unsigned char *prev_header_hash = all_tx + sizeof(block_header->all_tx);
   memcpy(prev_header_hash, &(block_header->prev_header_hash), sizeof(block_header->prev_header_hash));
 
-  char *nonce = prev_header_hash + sizeof(block_header->prev_header_hash);
+  unsigned char *nonce = prev_header_hash + sizeof(block_header->prev_header_hash);
   memcpy(nonce, &(block_header->nonce), sizeof(block_header->nonce));
 
-  char* terminate = nonce+sizeof(block_header->nonce);
+  unsigned char* terminate = nonce+sizeof(block_header->nonce);
   return terminate;
 }
 
-char *ser_blockheader_alloc(BlockHeader *block_header){
-  char *data = malloc(sizeof(BlockHeader));
+unsigned char *ser_blockheader_alloc(BlockHeader *block_header){
+  unsigned char *data = malloc(sizeof(BlockHeader));
   ser_blockheader(data, block_header);
   return data;
 }
 
 void hash_blockheader(BlockHeader *header, unsigned char *buf) {
-  char *header_buf;
+  unsigned char *header_buf;
   header_buf = ser_blockheader_alloc(header);
   hash_sha256(buf, header_buf, sizeof(BlockHeader));
   free(header_buf);
@@ -41,21 +41,21 @@ int size_block(Block *block){
   return size;
 }
 
-char *ser_block(char *dest, Block *block){
-  memcpy(dest, block->num_txs, sizeof(block->num_txs));
+unsigned char *ser_block(unsigned char *dest, Block *block){
+  memcpy(dest, &(block->num_txs), sizeof(block->num_txs));
 
-  char *block_header = dest + sizeof(block->num_txs);
-  char *txs = ser_blockheader(&(block->header), block_header);
+  unsigned char *block_header = dest + sizeof(block->num_txs);
+  unsigned char *txs = ser_blockheader(block_header, &(block->header));
 
   for(int i = 0; i < block->num_txs; i++){
-      char *txs = ser_tx(&(block->txs[i]), txs);
+      unsigned char *txs = ser_tx(txs, &(block->txs[i]));
   }
-  char *end = txs;
+  unsigned char *end = txs;
   return end;
 }
 
-char *ser_block_alloc(Block *block){
-  char *data = malloc(size_block(block));
+unsigned char *ser_block_alloc(Block *block){
+  unsigned char *data = malloc(size_block(block));
   ser_block(data, block);
   return data;
 }

--- a/src/core/globals/constants.c
+++ b/src/core/globals/constants.c
@@ -3,7 +3,7 @@
 #include <constants.h>
 
 // TODO: Actually implelement.
-int hash_sha256(unsigned char * output_hash, char * input_data, unsigned int input_sz){
+int hash_sha256(unsigned char * output_hash, unsigned char * input_data, unsigned int input_sz){
   memcpy(output_hash, input_data, TX_HASH_LEN);
   return 1;
 }

--- a/src/core/txs/base_tx.c
+++ b/src/core/txs/base_tx.c
@@ -4,29 +4,29 @@
 
 #include "base_tx.h"
 
-char *ser_utxo(UTXO *utxo){
-  char *data = malloc(sizeof(UTXO));
+unsigned char *ser_utxo(UTXO *utxo){
+  unsigned char *data = malloc(sizeof(UTXO));
   memcpy(data, &(utxo->amt), sizeof(utxo->amt));
 
-  char *sig = data + sizeof(utxo->amt);
+  unsigned char *sig = data + sizeof(utxo->amt);
   memcpy(sig, &(utxo->public_key_hash), sizeof(utxo->public_key_hash));
 
-  char *spent = sig + sizeof(utxo->public_key_hash);
+  unsigned char *spent = sig + sizeof(utxo->public_key_hash);
   memcpy(spent, &(utxo->spent), sizeof(utxo->spent));
 
   return data;
 }
 
-UTXO *dser_utxo(char *data){
+UTXO *dser_utxo(unsigned char *data){
   UTXO *new_UTXO = malloc(sizeof(UTXO));
 
   // Stolen from https://cboard.cprogramming.com/cplusplus-programming/43180-sizeof-struct-member-problem.html
   memcpy(&(new_UTXO->amt), data, sizeof(((UTXO*)0)->amt));
 
-  char *sig = data + sizeof(((UTXO*)0)->amt);
+  unsigned char *sig = data + sizeof(((UTXO*)0)->amt);
   memcpy(&(new_UTXO->public_key_hash), sig, sizeof(((UTXO*)0)->public_key_hash));
 
-  char *spent = sig + sizeof(((UTXO*)0)->public_key_hash);
+  unsigned char *spent = sig + sizeof(((UTXO*)0)->public_key_hash);
   memcpy(&(new_UTXO->spent), spent, sizeof(((UTXO*)0)->spent));
 
   return new_UTXO;
@@ -37,43 +37,43 @@ int size_tx(Transaction *tx){
     tx->num_inputs * sizeof(Input) + tx->num_outputs * sizeof(Output));
 }
 
-char *ser_tx( char *dest, Transaction *tx){
+unsigned char *ser_tx(unsigned char *dest, Transaction *tx){
   memcpy(dest, &(tx->num_inputs), sizeof(tx->num_inputs));
 
-  char *num_outputs = dest + sizeof(tx->num_inputs);
+  unsigned char *num_outputs = dest + sizeof(tx->num_inputs);
   memcpy(num_outputs, &(tx->num_outputs), sizeof(tx->num_outputs));
 
-  char *inputs = num_outputs + sizeof(tx->num_outputs);
+  unsigned char *inputs = num_outputs + sizeof(tx->num_outputs);
   memcpy(inputs, tx->inputs, tx->num_inputs * sizeof(Input));
 
-  char *outputs = inputs + tx->num_inputs * sizeof(Input);
+  unsigned char *outputs = inputs + tx->num_inputs * sizeof(Input);
   memcpy(outputs, tx->outputs, tx->num_outputs * sizeof(Output));
 
-  char * end = outputs + tx->num_outputs * sizeof(Output);
+  unsigned char * end = outputs + tx->num_outputs * sizeof(Output);
   return end;
 }
 
-char *ser_tx_alloc(Transaction *tx){
-  char *data = malloc(size_tx(tx));
+unsigned char *ser_tx_alloc(Transaction *tx){
+  unsigned char *data = malloc(size_tx(tx));
   ser_tx(data, tx);
   return data;
 }
 
-Transaction *deser_tx(char *data){
+Transaction *deser_tx(unsigned char *data){
   Transaction *new_tx = malloc(sizeof(Transaction));
 
   memcpy(&(new_tx->num_inputs), data, sizeof(int));
 
-  char *nm_outputs = data + sizeof(int);
+  unsigned char *nm_outputs = data + sizeof(int);
   memcpy(&(new_tx->num_outputs), nm_outputs, sizeof(int));
 
-  char *inputs = nm_outputs + sizeof(int);
-  int input_sz = new_tx->num_inputs * sizeof(Input);
+  unsigned char *inputs = nm_outputs + sizeof(int);
+  unsigned int input_sz = new_tx->num_inputs * sizeof(Input);
   new_tx->inputs = malloc(input_sz);
   memcpy(new_tx->inputs, inputs, input_sz);
 
-  char *outputs = inputs + input_sz;
-  int output_sz = new_tx->num_outputs * sizeof(Output);
+  unsigned char *outputs = inputs + input_sz;
+  unsigned int output_sz = new_tx->num_outputs * sizeof(Output);
   new_tx->outputs = malloc(output_sz);
   memcpy(new_tx->outputs, outputs, output_sz);
 
@@ -81,7 +81,7 @@ Transaction *deser_tx(char *data){
 }
 
 void hash_tx(Transaction *tx, unsigned char *buf) {
-  char *tx_buf;
+  unsigned char *tx_buf;
   int tx_buf_size;
 
   tx_buf_size = size_tx(tx);

--- a/src/includes/blocks/base_block.h
+++ b/src/includes/blocks/base_block.h
@@ -19,10 +19,10 @@ typedef struct Block{
 
 #endif
 
-char *ser_blockheader(char *dest, BlockHeader *block_header);
-char *ser_blockheader_alloc(BlockHeader *block_header);
+unsigned char *ser_blockheader(unsigned char *dest, BlockHeader *block_header);
+unsigned char *ser_blockheader_alloc(BlockHeader *block_header);
 void hash_blockheader(BlockHeader *header, unsigned char *buf);
 
 int size_block(Block *Block);
-char *ser_block(char *dest, Block *block);
-char *ser_block_alloc(Block *block);
+unsigned char *ser_block(unsigned char *dest, Block *block);
+unsigned char *ser_block_alloc(Block *block);

--- a/src/includes/globals/constants.h
+++ b/src/includes/globals/constants.h
@@ -10,4 +10,4 @@
  input_sz: number of bytes in input
  output_hash: unsigned * of size TX_HASH_LEN
  */
-int hash_sha256(unsigned char * output_hash, char * input_data, unsigned int input_sz); 
+int hash_sha256(unsigned char * output_hash, unsigned char * input_data, unsigned int input_sz); 

--- a/src/includes/txs/base_tx.h
+++ b/src/includes/txs/base_tx.h
@@ -11,14 +11,14 @@ typedef struct Output{
 } Output;
 
 typedef struct Input{
-  char signature[SIGNATURE_LEN];
+  unsigned char signature[SIGNATURE_LEN];
   unsigned char prev_tx_id[TX_HASH_LEN];
-  int prev_utxo_output;
+  unsigned int prev_utxo_output;
 } Input; 
 
 typedef struct Transaction{
-  int num_inputs;
-  int num_outputs;
+  unsigned int num_inputs;
+  unsigned int num_outputs;
   Input *inputs;
   Output *outputs;
 } Transaction;
@@ -29,17 +29,17 @@ typedef struct UTXO{
   short spent;
 } UTXO;
 
-char *ser_utxo(UTXO *utxo);
-UTXO *dser_utxo(char *data);
+unsigned char *ser_utxo(UTXO *utxo);
+UTXO *dser_utxo(unsigned char *data);
 
 /*
 Return Size of a transaction, used for serialization and memory allocation
 */
 int size_tx(Transaction *tx);
 
-char *ser_tx(char *dest, Transaction *tx);
-char *ser_tx_alloc(Transaction *tx);
-Transaction* deser_tx(char *data);
+unsigned char *ser_tx(unsigned char *dest, Transaction *tx);
+unsigned char *ser_tx_alloc(Transaction *tx);
+Transaction* deser_tx(unsigned char *data);
 void hash_tx(Transaction *tx, unsigned char *buf);
 
 void print_input(Input *input);

--- a/src/tests/core/txs/test_base_tx.c
+++ b/src/tests/core/txs/test_base_tx.c
@@ -8,7 +8,7 @@
 int main() {
   Output *an_Output = malloc(sizeof(Output));
   an_Output->amt = 5;
-  strcpy(an_Output->public_key_hash, "a_val");
+  strcpy((char*)an_Output->public_key_hash, "a_val");
 
   Input *an_Input = malloc(sizeof(Input));
   an_Input->prev_utxo_output = 2;
@@ -41,7 +41,7 @@ int main() {
   // //printf("prev_tx_id: %s\n", ((a_Tx->inputs)+1)->prev_tx_id);
 
   //Serialization Testing
-  char *char_tx = ser_tx_alloc(a_Tx);
+  unsigned char *char_tx = ser_tx_alloc(a_Tx);
 
   Transaction *other_tx = deser_tx(char_tx);
 


### PR DESCRIPTION
Changes all structs and corresponding test scripts to use unsigned chars and unsigned ints. Motivated by mbed-tls using unsigned chars for hash inputs and outputs. Also seems somewhat(?) justified as we are making a distinction between strings and our data buffers (probably doesn't matter).