### PR TITLE
Wallet Documentation

### DIFF
--- a/src/includes/txs/sign_tx.h
+++ b/src/includes/txs/sign_tx.h
@@ -8,17 +8,83 @@
 
 #define CURVE MBEDTLS_ECP_DP_SECP256K1
 
+/* KEY GENERATION */
+
+/**
+ * @brief Initializes the entropy objects
+ *
+ * Builds the entropy objects used in key generation and signing.
+ */
 void init_entropy();
+
+/**
+ * @brief Frees the entropy objects
+ *
+ * Frees the entropy objects used in key generation and signing.
+ */
 void free_entropy();
 
+/**
+ * @brief Generates a ECC key pair
+ *
+ * Generates a ECC key pair of curve specified by the CURVE constant.
+ * Initializes entropy objects if they aren't initialized.
+ *
+ * @return A new key pair
+ */
 mbedtls_ecdsa_context *gen_keys();
+
+/* SIGNATURE HANDLING */
+
+/**
+ * @brief Writes a signature
+ *
+ * Signs passed hash using passed key to passed destination.
+ *
+ * @param dest Destination buffer to write to
+ * @param dest_len Length of the destination buffer
+ * @param hash Hash buffer to sign
+ * @param hash_len Length of the hash buffer
+ * @param keys Key pair to sign with
+ * @return Number of bytes written
+ */
 size_t write_sig(
     unsigned char *dest, size_t dest_len,
     unsigned char *hash, size_t hash_len,
     mbedtls_ecdsa_context *keys
 );
+
+/* PUB KEY HANDLING */
+
+/**
+ * @brief Serialize a public key
+ *
+ * @param dest Destination buffer to serialize to
+ * @param point Public key to serialize. Can be accessed from key pair as
+ *   key_pair->MBEDTLS_PRIVATE(Q)
+ * @param grp Public key group. Can be accessed from key pair as
+ *   key_pair->MBEDTLS_PRIVATE(grp)
+ * @return Number of bytes written
+ */
 size_t ser_pub_key(unsigned char *dest, mbedtls_ecp_point *point, mbedtls_ecp_group *grp);
+
+/**
+ * @brief Deserialize a public key
+ *
+ * Deserializes a public key serialized with ser_pub_key()
+ *
+ * @param dest Destination key to write to
+ * @param grp Group of key we are reading
+ * @param data Source buffer containing serialized key
+ */
 void deser_pub_key(mbedtls_ecp_point *dest, mbedtls_ecp_group *grp, unsigned char *data);
+
+/**
+ * @brief Hash public key of a key pair
+ *
+ * @param dest Destination buffer to serialize to
+ * @param key_pair Key pair containing public key to hash
+ */
 void hash_pub_key(unsigned char *dest, mbedtls_ecdsa_context *key_pair);
 
 extern char *seed;

--- a/src/includes/txs/sign_tx.h
+++ b/src/includes/txs/sign_tx.h
@@ -39,7 +39,7 @@ mbedtls_ecdsa_context *gen_keys();
 /**
  * @brief Writes a signature
  *
- * Signs passed hash using passed key to passed destination.
+ * Signs passed hash using passed key to passed destination
  *
  * @param dest Destination buffer to write to
  * @param dest_len Length of the destination buffer
@@ -52,6 +52,24 @@ size_t write_sig(
     unsigned char *dest, size_t dest_len,
     unsigned char *hash, size_t hash_len,
     mbedtls_ecdsa_context *keys
+);
+
+/**
+ * @brief Validates a signature
+ *
+ * Validates a signature given a message hash and key pair
+ *
+ * @param sig Signature buffer to validate
+ * @param sig_len Length of the signature buffer
+ * @param hash Hash buffer to validate signture with
+ * @param hash_len Length of the hash buffer
+ * @param key_pair Key pair to validate signture with
+ * @return 0 if valid signature, 1 otherwise
+ */
+int validate_sig(
+    unsigned char *sig, size_t sig_len,
+    unsigned char *hash, size_t hash_len,
+    mbedtls_ecdsa_context *key_pair
 );
 
 /* PUB KEY HANDLING */

--- a/src/includes/txs/wallet.h
+++ b/src/includes/txs/wallet.h
@@ -1,3 +1,5 @@
+
+
 #pragma once
 
 #include "base_tx.h"
@@ -14,7 +16,50 @@ typedef struct {
   unsigned long out_total;  // Used internally
 } TxOptions;
 
+/**
+ * @brief Build the inputs for the given transaction.
+ *
+ * @param tx The transaction to add inputs to
+ * @param options The options for building the transaction. Only num_dests,
+ *  dests and tx_fee should be set. The in_total and out_total fields will be set
+ *  by the function.
+ * @return Array of key pairs, each corresponding to a new input in the
+ *  transaction. return[0] should sign tx->inputs[0], and so on.
+ */
 mbedtls_ecdsa_context **build_inputs(Transaction *tx, TxOptions *options);
+
+/**
+ * @brief Builds the outputs for the given transaction.
+ *
+ * @param tx The transaction to add outputs to
+ * @param options The options for building the transaction. All fields should be
+ *  set. It is expected that build_inputs() was called before hand.
+ * @return Single key pair that correspondes to the self-output. NULL if no
+ *  self-output was needed.
+ */
 mbedtls_ecdsa_context *build_outputs(Transaction *tx, TxOptions *options);
+
+/**
+ * @brief Signs the given transaction
+ *
+ * @param tx The transaction to sign
+ * @param keys Array of key pairs corresponding to the transaction inputs. It is
+ *  expected that this was returned by build_inputs()
+ */
 void sign_tx(Transaction *tx, mbedtls_ecdsa_context **keys);
+
+/**
+ * @brief Builds a transaction
+ *
+ * Builds a transaction given options. Collects transactions from the wallet
+ * pool such that the outputs and transaction fee can be fulfilled, then puts
+ * together the transaction. Creates an output with a new key pair stored in the
+ * key pool to handle "change"
+ *
+ * @param options The options for building the transaction. Only num_dests,
+ *  dests and tx_fee should be set. dests is an array of outputs describing the
+ *  outputs of the tx and tx_fee is the transaction fee to use. in_total and
+ *  out_total should not be set.
+ * @return A new transaction
+ */
 Transaction *build_tx(TxOptions *options);

--- a/src/includes/txs/wallet_pool.h
+++ b/src/includes/txs/wallet_pool.h
@@ -44,15 +44,104 @@ WalletPool *wallet_pool;
  */
 KeyPool *key_pool;
 
+/**
+ * @brief Initializes wallet
+ *
+ * Initializes the wallet pool and key pool
+ */
 void wallet_init();
 
+/* WALLET POOL FUNCTIONS */
+
+/**
+ * @brief Adds an entry to the wallet pool
+ *
+ * Creates a new WalletEntry using passed data, then adds new entry to the
+ * wallet pool. NOTE: Does not copy the passed key - only stores the pointer. We
+ * expect keys to be never freed.
+ *
+ * @param tx Transaction the new entry is a part of
+ * @param vout Output index of the new entry within the source transaction
+ * @param key_pair Key pair associated with the new entry
+ * @return New entry if succesfull, otherwise NULL
+ */
 WalletEntry *wallet_pool_add(Transaction *tx, unsigned int vout, mbedtls_ecdsa_context *key_pair);
+
+/**
+ * @brief Removes an entry from the wallet pool
+ *
+ * @param tx_hash Transaction hash corresponding to entry to find
+ * @param vout Output index corresponding to entry to find
+ */
 void wallet_pool_remove(unsigned char *tx_hash, unsigned int vout);
+
+/**
+ * @brief Finds an entry in the wallet pool
+ *
+ * @param tx_hash Transaction hash corresponding to entry to remove
+ * @param vout  Output index corresponding to entry to find
+ * @return Entry if found, otherwise NULL
+ */
 WalletEntry *wallet_pool_find(unsigned char *tx_hash, unsigned int vout);
+
+/**
+ * @brief Finds a node in the wallet pool
+ *
+ * Internal function that returns the WalletPool wrapper type instead of the
+ * WalletEntry type.
+ *
+ * @param tx_hash Transaction hash corresponding to entry to remove
+ * @param vout  Output index corresponding to entry to find
+ * @return Node if found, otherweise NULL
+ */
 WalletPool *wallet_pool_find_node(unsigned char *tx_hash, unsigned int vout);
+
+/**
+ * @brief Finds a node in the wallet pool
+ *
+ * Internal function that takes in a UTXOPoolKey and returns the WalletPool
+ * wrapper type instead of the WalletEntry type.
+ *
+ * @param key UTXOPoolKey containing tx_hash and vout
+ * @return Node if found, otherweise NULL
+ */
 WalletPool *wallet_pool_find_node_key(UTXOPoolKey *key);
 
+/* KEY POOL FUNCTIONS */
+
+/**
+ * @brief Adds a key pair to the key pool
+ *
+ * Stores the key pair in the key pool with the hash of the public key as the
+ * dictionary key
+ *
+ * @param key_pair Key pair to store
+ * @return Passed key pool if succesfull, NULL otherwise
+ */
 mbedtls_ecp_keypair *key_pool_add(mbedtls_ecp_keypair *key_pair);
+
+/**
+ * @brief Removes a key pair from the key pool
+ *
+ * @param public_key_hash Public key hash corresponding to key pair to remove
+ * @return Key pair if removed, otherwise NULL
+ */
 mbedtls_ecp_keypair *key_pool_remove(unsigned char *public_key_hash);
+
+/**
+ * @brief Finds a key pair in the key pool
+ *
+ * @param public_key_hash Public key hash corresponding to key pair to remove
+ * @return Key pair if found, otherwise NULL
+ */
 mbedtls_ecp_keypair *key_pool_find(unsigned char *public_key_hash);
+
+/**
+ * @brief Finds a node in the key pool
+ *
+ * Internal function that returns the KeyPool wrapper type instead of a key pair
+ *
+ * @param public_key_hash Public key hash corresponding to key pair to remove
+ * @return Node if found, otherwise NULL
+ */
 KeyPool *key_pool_find_node(unsigned char *public_key_hash);

--- a/src/tests/core/txs/test_wallet.c
+++ b/src/tests/core/txs/test_wallet.c
@@ -214,10 +214,10 @@ static char *test_sign_tx() {
   for (size_t i = 0; i < tx->num_inputs; i++) {
     mu_assert(
         "Input signature invalid",
-        mbedtls_ecdsa_read_signature(
-          ret_keys[i],
+        validate_sig(
+          tx->inputs[i].signature, tx->inputs[i].sig_len,
           tx_hash, TX_HASH_LEN,
-          tx->inputs[i].signature, tx->inputs[i].sig_len
+          ret_keys[i]
         ) == 0
     );
   }


### PR DESCRIPTION
Some cleanup for already merged wallet code.
- Adds docstrings to `wallet.h`, `wallet_pool.h` and `sign_tx.h`
- Adds a new `validate_sig()` function
- Cleans up error message in `sign_tx.c`
We should go back and update the older docstrings to be in doxygen format at some point, but I think its out of scope here and definitely not a priority.